### PR TITLE
Make pritunl_client_version configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for ansible-role-pritunl-client
 
 pritunl_client_package: pritunl-client
+pritunl_client_version: 1.0.1361.39-0ubuntu1~{{ ansible_distribution_release }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for ansible-role-pritunl-client
 
 pritunl_client_package: pritunl-client
-pritunl_client_version: 1.0.1361.39-0ubuntu1~{{ ansible_distribution_release }}
+pritunl_client_version: '*'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for ansible-role-pritunl-client
 
 pritunl_client_package: pritunl-client
-pritunl_client_version: '*'
+pritunl_client_version: 1.0.1562.28-0ubuntu1~{{ ansible_distribution_release }}

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -5,3 +5,9 @@ RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && a
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi
+
+{% if item.provision is defined %}
+{% for cmdline in item.provision %}
+RUN {{ cmdline }}
+{% endfor %}
+{% endif %}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,10 +17,14 @@ platforms:
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
+    provision:
+      - echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
 
   - name: trusty
     image: ubuntu-upstart:14.04
     command: "/sbin/init"
+    provision:
+      - echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,10 +22,6 @@ platforms:
     image: ubuntu-upstart:14.04
     command: "/sbin/init"
 
-  - name: precise
-    image: ubuntu-upstart:12.04
-    command: "/sbin/init"
-
 provisioner:
   name: ansible
   lint:

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -23,12 +23,12 @@ when '12.04'
 when '14.04'
   describe package('pritunl-client') do
     it { should be_installed }
-    its('version') { should eq '1.0.1361.39-0ubuntu1~trusty' }
+    its('version') { should eq '1.0.1562.28-0ubuntu1~trusty' }
   end
 when '16.04'
   describe package('pritunl-client') do
     it { should be_installed }
-    its('version') { should eq '1.0.1361.39-0ubuntu1~xenial' }
+    its('version') { should eq '1.0.1562.28-0ubuntu1~xenial' }
   end
 end
 

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -15,11 +15,6 @@ describe apt('http://repo.pritunl.com/stable/apt') do
 end
 
 case os[:release]
-when '12.04'
-  describe package('pritunl-client') do
-    it { should be_installed }
-    its('version') { should eq '1.0.1361.39-0ubuntu1~precise' }
-  end
 when '14.04'
   describe package('pritunl-client') do
     it { should be_installed }

--- a/test/test.sh
+++ b/test/test.sh
@@ -24,7 +24,6 @@ echo "Running integration tests with inspec..."
 echo ""
 inspec exec --no-color test/smoke/default -t docker://xenial
 inspec exec --no-color test/smoke/default -t docker://trusty
-inspec exec --no-color test/smoke/default -t docker://precise
 
 # clean up
 molecule destroy

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -3,4 +3,3 @@
 
 pritunl_client_key: 7568D9BB55FF9E5287D586017AE645C0CF8E292A
 pritunl_client_repo: deb http://repo.pritunl.com/stable/apt {{ ansible_distribution_release }} main
-pritunl_client_version: 1.0.1361.39-0ubuntu1~{{ ansible_distribution_release }}


### PR DESCRIPTION
With this PR it is possible to override version.
I need this because '1.0.1361.39-0ubuntu1~xenial' does not exist in the xenial apt repository